### PR TITLE
MPHit & Other Stuff

### DIFF
--- a/butts/b_compile.sqf
+++ b/butts/b_compile.sqf
@@ -4,7 +4,7 @@ if (hasInterface) then {
 	//butts_addac = compile preprocessFileLineNumbers "butts\b_actions.sqf";
 
 	[player] execVM "butts\b_actions.sqf";
-//	[player] execVM "butts\pad_lights.sqf";
+
 	//butts scripts
 	butts_fuel = compile preprocessFileLineNumbers "butts\butts_veh_refuel.sqf";
 	butts_at = compile preprocessFileLineNumbers "butts\uav_at.sqf";

--- a/core/fnc/cache/create.sqf
+++ b/core/fnc/cache/create.sqf
@@ -5,7 +5,7 @@ btc_cache_obj = selectRandom btc_cache_type createVehicle btc_cache_pos;
 btc_cache_obj setPosATL btc_cache_pos;
 btc_cache_obj setDir (random 360);
 clearWeaponCargoGlobal btc_cache_obj;clearItemCargoGlobal btc_cache_obj;clearMagazineCargoGlobal btc_cache_obj;
-btc_cache_obj addEventHandler ["HandleDamage", btc_fnc_cache_hd_cache];
+btc_cache_obj addMPEventHandler ["MPHit", btc_fnc_cache_hd_cache];
 
 _pos_type_array = ["TOP","FRONT","CORNER_L","CORNER_R"];
 

--- a/core/fnc/cache/hd_cache.sqf
+++ b/core/fnc/cache/hd_cache.sqf
@@ -3,11 +3,9 @@ private ["_cache","_damage","_ammo","_explosive"];
 
 _cache = _this select 0;
 _damage = _this select 2;
-_ammo = _this select 4;
+_ammo = _this select 1;
 
-_explosive = (getNumber(configFile >> "cfgAmmo" >> _ammo >> "explosive") > 0);
-
-if (isNil {_cache getVariable "btc_hd_cache"} && {_explosive} && {_damage > 0.01}) then {
+if (isNil {_cache getVariable "btc_hd_cache"} && _damage > 1) then {
     _cache setVariable ["btc_hd_cache",true];
     {detach _x; deleteVehicle _x;} forEach attachedObjects _cache;
 	 _pos = getposATL btc_cache_obj;
@@ -36,4 +34,6 @@ if (isNil {_cache getVariable "btc_hd_cache"} && {_explosive} && {_damage > 0.01
     [0] remoteExec ["btc_fnc_show_hint", 0];
 
     [] spawn {[] call btc_fnc_cache_find_pos;};
-} else {0};
+} else {
+    _cache setDamage 0;
+};

--- a/core/fnc/cache/spawn.sqf
+++ b/core/fnc/cache/spawn.sqf
@@ -5,7 +5,7 @@ btc_cache_pos = selectRandom (_this buildingPos -1);
 
 // If the building doesn't have any preset positions, nothing is returned
 // Try again I guess...
-if (isNil "btc_cache_pos") exitWith
+if (isNil "btc_cache_pos" || count btc_cache_pos <= 1) exitWith
 {
 	[] spawn {[] call btc_fnc_cache_find_pos;};
 

--- a/core/fnc/cache/spawn.sqf
+++ b/core/fnc/cache/spawn.sqf
@@ -1,11 +1,16 @@
+// Params: A building is passed in from /core/fnc/find_pos.sqf
 
-private ["_n_pos","_max_pos"];
+// Randomly select one of the building's preset positions
+btc_cache_pos = selectRandom (_this buildingPos -1);
 
-_n_pos = 0;
-while {format ["%1", _this buildingPos _n_pos] != "[0,0,0]" } do {_n_pos = _n_pos + 1};
-_max_pos = _n_pos;
-_n_pos   = floor (random _max_pos);
+// If the building doesn't have any preset positions, nothing is returned
+// Try again I guess...
+if (isNil "btc_cache_pos") exitWith
+{
+	[] spawn {[] call btc_fnc_cache_find_pos;};
 
-btc_cache_pos = (_this buildingPos _n_pos);
-if (btc_cache_pos distance [0,0,0] < 10) exitWith {[] spawn {[] call btc_fnc_cache_find_pos;};};
+	// Todo: Spawn the cache somewhere outside the invalid building and throw a 
+	// camonet over it instead trying again.
+};
+
 call btc_fnc_cache_create;

--- a/init.sqf
+++ b/init.sqf
@@ -7,6 +7,7 @@ call compile preprocessFile "define_mod.sqf";
 
 if (isServer) then {
     call compile preprocessFile "core\init_server.sqf";
+    call compile preprocessFile "butts\pad_lights.sqf";
 };
 
 call compile preprocessFile "core\init_common.sqf";
@@ -18,6 +19,6 @@ if (!isDedicated && hasInterface) then {
 if (!isDedicated && !hasInterface) then {
     call compile preprocessFile "core\init_headless.sqf";
 };
+
 // call butt scripts
-//call compile preprocessFile "butts\pad_lights.sqf";
 call compile preprocessFile "butts\b_compile.sqf";

--- a/initPlayerLocal.sqf
+++ b/initPlayerLocal.sqf
@@ -1,1 +1,0 @@
-[] execVM "butts\pad_lights.sqf";


### PR DESCRIPTION
Use MPHit multiplayer event handler to track the lifetime of the cache crates. MPHit is global so won't disappear if the crate is move to a player's client. 

Use a more efficient means of determining box placement inside a building. 

Landing pad lights being created only once on the server instead of every time a player inits.